### PR TITLE
Fix README typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 # chat
-descirbe
+describe


### PR DESCRIPTION
## Summary
- fix a typo in README

## Testing
- `pytest -q` *(fails: command not found)*